### PR TITLE
hintの単位の指定

### DIFF
--- a/jaunte.el
+++ b/jaunte.el
@@ -48,7 +48,7 @@
 
 (defvar jaunte-local-hint-unit nil
   "local hint unit. This variable is buffer local variable")
-(make-local-variable 'jaunte-local-hint-unit)
+(make-variable-buffer-local 'jaunte-local-hint-unit)
 
 (defun jaunte-forward-word ()
   "Move to beginning of a forward word, and return point."


### PR DESCRIPTION
もともとは hintは wordごとに表示されていましたが、それを選択できる
ようにしました。選択肢は thing-at-pointと同様です。またバッファ単位での
hintの単位を選択できるようにしました。これにより、hook関数を使えば
特定のモードのみ違う単位での hintの表示が可能です。

```
(setq jaunte-global-hint-unit 'line)
```

例えば上記のようにすると、行ごとに hintが表示されます。wordや lineの
他には空白区切りの whitespaceや S式単位の sexpが指定できます。

ローカルに hint単位を指定したい場合は,  jaunte-local-hint-unitに単位を
指定します。globalと localの指定がある場合は localの方の設定が優先
されます。

あとこれとは関係ないですが、cl.elに定義されている関数 oddpが使われて
いたので、require clを追加しました。

新機能の提案ということになりますが、
ご検討のほどよろしくお願いします。
