### PR TITLE
Fix file header for ELPA compatibility

### DIFF
--- a/jaunte.el
+++ b/jaunte.el
@@ -1,4 +1,4 @@
-;; jaunte.el --- Emacs Hit a Hint
+;;; jaunte.el --- Emacs Hit a Hint
 
 ;; 参考
 ;; yafastnav.el


### PR DESCRIPTION
With this fix, the file can be installed using `package.el`, e.g. from the convenient packages automatically built by MELPA (http://melpa.milkbox.net).
